### PR TITLE
Reuse and extend external YAML definition + stage macro improvements

### DIFF
--- a/integration_tests/models/structural/storage/stage/TEST_STAGE__EXTERNAL_CONFIG_LOCALLY_EXTENDED.sql
+++ b/integration_tests/models/structural/storage/stage/TEST_STAGE__EXTERNAL_CONFIG_LOCALLY_EXTENDED.sql
@@ -1,0 +1,26 @@
+
+{%- set local_yaml_config -%}
+source: {{ config.require('source') }}
+calculated_columns: {{ config.require('calculated_columns') }}
+hashed_columns: {{ config.require('hashed_columns') }}
+default_records: {{ config.require('default_records') }}
+remove_duplicates: {{ config.require('remove_duplicates') }}
+
+flat_dict_calculated_columns:                                   #-- Merging dictionaries => YES ADD & REDEFINE Keys
+  <<: {{ config.get('calculated_columns') }}                    #-- Importing the FLATTENED dict from the CFG
+  EFFECTIVITY_DATE: "'{{ run_started_at }}'::TIMESTAMP_NTZ"     #-- Added column EFFECTIVITY_DATE
+  COLUMN_4: "'9999-09-09'::timestamp"                           #-- Redefined COLUMN_4
+
+{%- endset -%}
+
+{%- set metadata_dict = fromyaml(local_yaml_config) -%}
+
+{{- pragmatic_data.stage(
+    source_model            = ref('GENERIC_TWO_COLUMN_TABLE'),
+    source                  = metadata_dict['source'],
+    calculated_columns      = metadata_dict['flat_dict_calculated_columns'],
+    hashed_columns          = metadata_dict['hashed_columns'],
+    default_records         = metadata_dict['default_records'],
+    remove_duplicates       = metadata_dict['remove_duplicates']
+) }}
+

--- a/integration_tests/models/structural/storage/stage/test_stage.yml
+++ b/integration_tests/models/structural/storage/stage/test_stage.yml
@@ -84,3 +84,19 @@ models:
          exclude_columns:
           - COLUMN_4     
           - EFFECTIVITY_DATE
+
+  - name: TEST_STAGE__EXTERNAL_CONFIG_LOCALLY_EXTENDED
+    config:
+      source_columns:     *stg_model_source_columns
+      source:             *stg_model_source
+      calculated_columns: *stg_model_calculated_columns
+      default_records:    *security_default_records
+      hashed_columns:     *stg_model_hashed_columns
+      remove_duplicates: 
+    data_tests:
+     - dbt_utils.equality:
+         compare_model: ref('TEST_STAGE__EXPECTED')
+         exclude_columns:
+          - COLUMN_4     
+          - EFFECTIVITY_DATE
+


### PR DESCRIPTION
* Added a test model to re-process the external YAML metadata locally in the model, to extend or change the external definition.

* Strengthened the stage macro to avoid NoneType exceptions in such scenario.